### PR TITLE
terraform: add dns_nameservers to subnet definition

### DIFF
--- a/terraform/wireguard/garr-ct1/network.tf
+++ b/terraform/wireguard/garr-ct1/network.tf
@@ -15,6 +15,7 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
   name = var.subnet_name
   network_id = openstack_networking_network_v2.network_1.id
   cidr = var.subnet_cidr
+  dns_nameservers = var.subnet_dns_nameservers
   ip_version = 4
 }
 

--- a/terraform/wireguard/garr-ct1/terraform.tfvars.example
+++ b/terraform/wireguard/garr-ct1/terraform.tfvars.example
@@ -5,4 +5,5 @@ port_name = "wg_port"
 network_name = "wg_network"
 subnet_name = "wg_subnet"
 subnet_cidr = "192.168.168.0/24"
+subnet_dns_nameservers = ["193.206.141.38", "193.206.141.42"]
 router_name = "wg_router"

--- a/terraform/wireguard/garr-ct1/variables.tf
+++ b/terraform/wireguard/garr-ct1/variables.tf
@@ -42,6 +42,12 @@ variable "subnet_cidr" {
   description = "Subnet CIDR"
 }
 
+variable "subnet_dns_nameservers" {
+  type = list(string)
+  description = "Subnet DNS nameservers"
+  default = ["8.8.8.8"]
+}
+
 variable "router_name" {
   type = string
   description = "Name of the router"

--- a/terraform/wireguard/garr-pa1/network.tf
+++ b/terraform/wireguard/garr-pa1/network.tf
@@ -15,6 +15,7 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
   name = var.subnet_name
   network_id = openstack_networking_network_v2.network_1.id
   cidr = var.subnet_cidr
+  dns_nameservers = var.subnet_dns_nameservers
   ip_version = 4
 }
 

--- a/terraform/wireguard/garr-pa1/terraform.tfvars.example
+++ b/terraform/wireguard/garr-pa1/terraform.tfvars.example
@@ -5,4 +5,5 @@ port_name = "wg_port"
 network_name = "wg_network"
 subnet_name = "wg_subnet"
 subnet_cidr = "192.168.167.0/24"
+subnet_dns_nameservers = ["193.206.141.38", "193.206.141.42"]
 router_name = "wg_router"

--- a/terraform/wireguard/garr-pa1/variables.tf
+++ b/terraform/wireguard/garr-pa1/variables.tf
@@ -42,6 +42,13 @@ variable "subnet_cidr" {
   description = "Subnet CIDR"
 }
 
+variable "subnet_dns_nameservers" {
+  type = list(string)
+  description = "Subnet DNS nameservers"
+  default = ["8.8.8.8"]
+}
+
+
 variable "router_name" {
   type = string
   description = "Name of the router"


### PR DESCRIPTION
Added dns_nameservers to subnet definitions. DNS nameservers defined in the subnet are injected to the VMs. VMs must be able to resolve external repositories in order to execute the ansible playbook